### PR TITLE
Update row headings

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,7 +5,7 @@ Cerner Corporation
 - Matt Butler [@matt-butler]
 - Rory Hardy [@gneatgeek]
 - Tao Zhang [@windse7en]
-
+- Byron Varberg [@bvarberg]
 
 
 [@bjankord]: https://github.com/bjankord
@@ -13,3 +13,4 @@ Cerner Corporation
 [@matt-butler]: https://github.com/matt-butler
 [@gneatgeek]: https://github.com/gneatgeek
 [@windse7en]:https://github.com/windse7en
+[@bvarberg]:https://github.com/bvarberg

--- a/docs/themeable-variables.md
+++ b/docs/themeable-variables.md
@@ -17,6 +17,8 @@ Variables to `theme` the terra-table component.
 | $terra-table-cell-small-padding-right     | 0.75em         | Set the table-cell padding right                            |
 | $terra-table-cell-small-padding-bottom    | 0.25em         | Set the table-cell padding bottom                           |
 | $terra-table-cell-small-padding-left      | 0.75em         | Set the table-cell padding left                             |
+| $terra-table-row-th-background-color      | $terra-grey-10 | Set the table-row table-heading background color            |
+| $terra-table-row-striped-th-background-color | $terra-grey-20 | Set the table-row table-heading background color for the striped modifier |
 | $terra-table-row-striped-background-color | $terra-grey-10 | Set the table-row background color for the striped modifier |
 | $terra-table-tfoot-border-color           | $terra-grey-30 | Set the tfoot border color                                  |
 | $terra-table-tfoot-border-width           | 1px            | Set the tfoot border width                                  |

--- a/src/terra-table.scss
+++ b/src/terra-table.scss
@@ -96,6 +96,12 @@
       vertical-align: bottom;
     }
 
+    tbody th {
+      @include terra-text-align-end;
+
+      background-color: $terra-table-row-th-background-color;
+    }
+
     tfoot tr {
       @include terra-text-align-start;
 
@@ -126,6 +132,10 @@
   @media screen and (min-width: $terra-small-breakpoint) {
     tbody tr:nth-of-type(even) {
       background-color: $terra-table-row-striped-background-color;
+    }
+
+    tbody tr:nth-of-type(even) th {
+      background-color: $terra-table-row-striped-th-background-color;
     }
   }
 }

--- a/src/terra-table.scss
+++ b/src/terra-table.scss
@@ -133,7 +133,9 @@
     tbody tr:nth-of-type(even) {
       background-color: $terra-table-row-striped-background-color;
     }
-
+    
+    /* Compound selector depth required for specificity */
+    /* stylelint-disable-next-line selector-max-compound-selectors */
     tbody tr:nth-of-type(even) th {
       background-color: $terra-table-row-striped-th-background-color;
     }

--- a/src/terra/table/_variables.scss
+++ b/src/terra/table/_variables.scss
@@ -13,6 +13,8 @@ $terra-table-cell-small-padding-bottom: 0.25em !default;
 $terra-table-cell-small-padding-left: 0.75em !default;
 $terra-table-cell-small-padding-right: 0.75em !default;
 $terra-table-cell-small-padding-top: 0.25em !default;
+$terra-table-row-th-background-color: $terra-grey-10 !default;
+$terra-table-row-striped-th-background-color: $terra-grey-20 !default;
 $terra-table-row-striped-background-color: $terra-grey-10 !default;
 $terra-table-tfoot-border-color: $terra-grey-30 !default;
 $terra-table-tfoot-border-width: 1px !default;


### PR DESCRIPTION
### Summary
End aligns row headings using the `terra-text-align-end` from `terra-mixins`. Also, adds a background-color to row headings for both base and stripe-modified tables matching legacy Terra styling.

Addresses issue #5. 

### Additional Details
I played around with a couple of ways for adding the background-color to the row heading in the stripe-modified table. Each way I tried adding the styling violated a stylelint rule. The included implementation violates the least (only the `selector-max-compound-selectors` rule, by one selector) -- but I didn't want to add an ignore statement for that line without consulting the maintainers.

All this to say, I expect it to fail the stylelint validation as is, and I'm hoping for guidance on how to address the problem, either with a different implementation or permission to bend the stylelint rules.